### PR TITLE
bcdice-js v3への対応: コマンドではない場合はbcdiceに処理を投げないように

### DIFF
--- a/src/app/class/dice-bot.ts
+++ b/src/app/class/dice-bot.ts
@@ -114,31 +114,22 @@ export class DiceBot extends GameObject {
     if (chatTab) chatTab.addMessage(diceBotMessage);
   }
 
-  static diceRollAsync(message: string, gameType: string): Promise<DiceRollResult>
-  static diceRollAsync(message: string, gameSystem: GameSystemClass): Promise<DiceRollResult>
-  static diceRollAsync(message: string, arg: any): Promise<DiceRollResult> {
-    return DiceBot.queue.add(async (resolve, reject) => {
+  static diceRollAsync(message: string, gameSystem: GameSystemClass): Promise<DiceRollResult> {
+    return DiceBot.queue.add(() => {
       try {
-        let gameSystem: GameSystemClass;
-        if (typeof arg === 'string') {
-          gameSystem = await DiceBot.loadGameSystemAsync(arg);
-        } else {
-          gameSystem = arg;
-        }
         const result = gameSystem.eval(message);
         if (result) {
           console.log('diceRoll!!!', result.text);
           console.log('isSecret!!!', result.secret);
-          resolve({
+          return {
             result: `${gameSystem.ID} : ${result.text}`,
             isSecret: result.secret,
-          });
-          return;
+          };
         }
       } catch (e) {
         console.error(e);
       }
-      resolve({ result: '', isSecret: false });
+      return { result: '', isSecret: false };
     });
   }
 


### PR DESCRIPTION
TK11235#157 
```
2
説明文
```
のようなチャットメッセージが繰り返しコマンドとして処理されててダサかったので、その修正です。
![image](https://user-images.githubusercontent.com/7685946/113504178-65ff3800-9571-11eb-8754-3dc80195a1a9.png)

この対応で完全に防げるわけではなく、「説明文」の箇所`COMMAND_PATTERN`に前方一致してしうような場合は変わらず上記の事象が発生します。具体的には
- 数字
- `+-(`
- `C`または`D`

などです。この内、`C`,`D`と`+-(`についてはBCDice側で修正されたので、いずれ事象が発生しなくなります。(bcdice-js 3.2.0以降)
ref.) https://github.com/bcdice/BCDice/blob/2f36fb3cf9923ad2f360e974b162242722d88bb1/test/test_base.rb#L12

また、BCDiceのバージョンによって、ダイスボットのリストに無いgameTypeなどが発生しうるので、
その際にエラーが出ないようにする対応も行いました。

こちらで挙動は確認できます https://udon-bcdicejsv3.netlify.app/